### PR TITLE
Source Call Escaping and --debug

### DIFF
--- a/scalu/scalu.py
+++ b/scalu/scalu.py
@@ -6,7 +6,7 @@ import scalu.src.cli.output_handling as output_handler
 
 
 def main():
-    args = arg_handler.handle()
+    args = arg_handler.args
     if args.mode[0] == 'compile':
         file_input = input_handler.handle(args.input)
         text_output = scalu(file_input, args)

--- a/scalu/src/backend/backend.py
+++ b/scalu/src/backend/backend.py
@@ -2,13 +2,13 @@ import scalu.src.backend.generation.abstract_generation as gen
 import scalu.src.backend.emission.emission as emission
 import scalu.src.minify.minify as minifier
 import scalu.src.model.file as files
+import scalu.src.cli.arg_handling as arg_handler
 
 
 def compile(global_object):
-    debug = False
     gen.compile(global_object)
     raw_program = emission.emission(global_object.universe)
-    if debug:
+    if arg_handler.args.debug:
         print(raw_program)
     minified_program = minifier.minify(raw_program, global_object.universe)
     file_directive = files.file_container(global_object, minified_program)

--- a/scalu/src/backend/generation/abstract_generation.py
+++ b/scalu/src/backend/generation/abstract_generation.py
@@ -31,7 +31,7 @@ def build_bindings(global_object):
             uni.root.extend(model.bind(event.key, event_compute))
 
 def build_events(global_object):
-    args = arg_handler.handle()
+    args = arg_handler.args
     uni = global_object.universe
     for event in global_object.maps.maps:
         event_def = uni.new_def('event')

--- a/scalu/src/cli/arg_handling.py
+++ b/scalu/src/cli/arg_handling.py
@@ -58,6 +58,14 @@ def handle():
         dest='aliasprefix',
         help='specify the prefix used for internal aliases'
     )
+    parser.add_argument(
+        '--debug',
+        '-dbg',
+        action='store_true',
+        default=False,
+        dest='debug',
+        help='run in debug mode'
+    )
 
     args = parser.parse_args()
 
@@ -65,3 +73,5 @@ def handle():
         raise Exception('scalu must be provided with a command to run: compile, test, etc')
 
     return args
+
+args = handle()

--- a/scalu/src/frontend/frontend.py
+++ b/scalu/src/frontend/frontend.py
@@ -3,17 +3,18 @@ import scalu.src.frontend.parser.parser as parser
 import scalu.src.preprocess.preprocess as preprocess
 import scalu.src.visualize.visualize as visualize
 import scalu.src.frontend.unwrapper.unwrapper as unwrapper
+import scalu.src.cli.arg_handling as arg_handler
 
 
 def compile(program_string):
-    debug = False
+    args = arg_handler.handle()
     #program_string = preprocess.preprocess(program_string)
     program_tokens = lexer.tokenize(program_string)
     syntax_tree = parser.parse(program_tokens)
-    if debug:
+    if args.debug:
         visualize.visualize(syntax_tree)
     unwrapped_ast = unwrapper.unwrap(syntax_tree)
-    if debug:
+    if args.debug:
         print('**********')
         visualize.visualize_unwrapping(unwrapped_ast)
     return syntax_tree

--- a/scalu/src/frontend/lexer/lexer.py
+++ b/scalu/src/frontend/lexer/lexer.py
@@ -12,7 +12,7 @@ class token():
         self.line = line
 
 def split_on_word(program):
-    return re.split('(\/\*[\s\S]*?\*\/|\[[\s\S]*?\]|-\w+|\+\w+|>>|<<|<=|>=|!=|==|\W)', program)
+    return re.split('(\/\*[\s\S]*?\*\/|\[[\s\S]*?(?<!\\\)\]|-\w+|\+\w+|>>|<<|<=|>=|!=|==|\W)', program)
     #this regex splits on comments, console blocks, negative events, positive events, and various operators
 
 def to_tokens(split_program):

--- a/scalu/src/frontend/parser/expect.py
+++ b/scalu/src/frontend/parser/expect.py
@@ -185,7 +185,7 @@ def expect_call(consumer):
 def expect_source_call(consumer):
     new_source_call = model.source_call()
     consumer.consume('[')
-    new_source_call.arg[0] = consumer.token()
+    new_source_call.arg[0] = consumer.token().replace("\]", "]")
     new_source_call.identifier = '[' + consumer.token() + ']'
     consumer.consume()
     consumer.consume(']')

--- a/scalu/src/minify/minify.py
+++ b/scalu/src/minify/minify.py
@@ -18,6 +18,7 @@ def clean_output(output_text):
     output_text = re.sub(';(\s*)\"', '"', output_text)
     output_text = re.sub('\";', '"', output_text)
     output_text = re.sub('\n{2,}', '\n', output_text)
+    output_text = re.sub('(?<!\\\)\\\]', ']', output_text)
     return output_text
 
 def minify_names(blob):

--- a/scalu/src/minify/minify.py
+++ b/scalu/src/minify/minify.py
@@ -18,7 +18,6 @@ def clean_output(output_text):
     output_text = re.sub(';(\s*)\"', '"', output_text)
     output_text = re.sub('\";', '"', output_text)
     output_text = re.sub('\n{2,}', '\n', output_text)
-    output_text = re.sub('(?<!\\\)\\\]', ']', output_text)
     return output_text
 
 def minify_names(blob):

--- a/scalu/src/model/file.py
+++ b/scalu/src/model/file.py
@@ -4,7 +4,7 @@ import scalu.src.cli.arg_handling as arg_handler
 class file_container():
 
     def __init__(self, global_object, main_text):
-        args = arg_handler.handle()
+        args = arg_handler.args
         self.buffers()
         self.files = list()
         self.host_files = self.create_host_files('scalu', main_text)

--- a/scalu/src/model/universe.py
+++ b/scalu/src/model/universe.py
@@ -5,12 +5,12 @@ import scalu.src.cli.arg_handling as arg_handler
 class universe():
 
     def __init__(self):
-        self.args = arg_handler.handle()
+        self.args = arg_handler.args
         self.computations = list()
         self.vars = list()
         self.known_aliases = list()
         self.alias_to_def = dict()
-        self.picker = picker(self.args)
+        self.picker = picker()
         self.constructs = dict()
         self.constant_constructs = list()
         self.initialized = False
@@ -118,7 +118,6 @@ def get_bin(value, word_size):
 class variable():
 
     def __init__(self, global_object, var):
-        debug = False
         uni = global_object.universe
         self.value = var.value
         self.bool_string = get_bin(var.value, var.word_size)
@@ -137,13 +136,13 @@ class variable():
                 uni.root.extend(self.set_true[bit].alias)
             else:
                 raise Exception('is not valid boolean string')
-        if debug:
+        if arg_handler.args.debug:
             print('creating var ' + var.name)
 
 class picker():
 
-    def __init__(self, args):
-        self.args = args
+    def __init__(self):
+        self.args = arg_handler.args
         self.symbols = list()
         self.current_use = 1
         lower_case_letters = range(97,123)

--- a/scalu/testing/frontend/parser/parser_test.py
+++ b/scalu/testing/frontend/parser/parser_test.py
@@ -87,6 +87,15 @@ class TestParsing(unittest.TestCase):
         program = self.blueprint_two_chain + '{ a = 7 [echo test_console_command_in_service] }'
         self.compiler.text_compile(program)
 
+    def test_console_command_escaping(self):
+        program = self.blueprint_two_chain + '{ a = 7 [echo test_console_command_escaping\]] }'
+        self.compiler.text_compile(program)
+
+    @unittest.expectedFailure
+    def test_console_command_escaped_end(self):
+        program = self.blueprint_two_chain + '{ a = 7 [echo test_console_command_escaped_end\] }'
+        self.compiler.text_compile(program)
+
     def test_service_call(self):
         program = self.blueprint_two_chain + '{ a = 3 @test_service2} service test_service2 { [echo old input was] a = ?a [echo new ouput is] a = ?5 }'
         self.compiler.text_compile(program)

--- a/scalu/testing/test_bootstrap.py
+++ b/scalu/testing/test_bootstrap.py
@@ -19,7 +19,7 @@ def test():
     #runner.run(preprocessing)
 
 def test_interpreter(verbose=True):
-    args = arg_handler.handle()
+    args = arg_handler.args
     con = native_console()
     program = ''
     with open('scalu/native/test.scalu', 'r') as file:


### PR DESCRIPTION
Closing bracket escaping done by `\]`, will result in `]`. If there is more than one `\`, it remains unchanged. This means that `\]` is impossible to put in source calls now, but I couldn't find a way to fix that, feel free to if you want.

--debug and -dbg now enable the few `debug = False` statements you had.
In the process, I also redid how args were handled, rather than the costly .handle() function every time they are needed, handle() is only called per file that needs it.

Resolves #37 