### PR TITLE
Add pow() and sqrt() services to standard library

### DIFF
--- a/scalu/native/std.scalu
+++ b/scalu/native/std.scalu
@@ -8,6 +8,8 @@ divide: @divide
 rng: @rng
 entropy_rng: @entropy_rng
 char: @char
+pow: @pow
+sqrt: @sqrt
 }
 
 
@@ -73,7 +75,63 @@ service divide2 {
 		output = 0 /* clamp to zero */
 	}
 }
-		
+
+/* base = input, exponent = input2, product = output */
+service pow {
+	if (input2 == 0) {
+		output = 1
+	}
+	else {
+		temp5 = input2
+		input2 = input 		/* For calling multiply service in pow2 */
+		@pow2
+	}
+}
+
+service pow2 {
+	if (temp5 == 1) {
+		output = input
+	} else {
+		@multiply
+		input = output
+		temp5 = temp5 - 1
+		@pow2
+	}
+}
+
+/* num to find sq of = input, floor(sqrt) = output */
+service sqrt {
+	output = 0
+	temp2 = 1 << 6 /* The second from top bit is set */
+	temp3 = 0
+	temp4 = input
+	@sqrt2
+}
+
+service sqrt2 {
+	if (temp4 < temp2) {
+		temp2 = temp2 >> 2
+		@sqrt2
+	} else {
+		@sqrt3
+	}
+}
+
+service sqrt3 {
+	if (temp2 != 0) {
+		temp3 = output + temp2
+		if (temp4 < temp3) {
+			output = output >> 1
+		}
+		else {
+			temp4 = temp4 - (output + temp2)
+			output = (output >> 1) + temp2
+		}
+		temp2 = temp2 >> 2
+		@sqrt3
+	}
+}
+
 /* rng value = rng */
 service rng {
     rng = rng + 1

--- a/scalu/native/test.scalu
+++ b/scalu/native/test.scalu
@@ -485,6 +485,67 @@ service test {
     if (std.output == 3) {[echo Passed]} else {[echo failed]}
 }
 
+sandbox test_std_pow
+
+map {
+    test_event: @test
+}
+
+service test {
+    [echo testing std pow]
+    [echo test 1]
+    std.input = 6
+    std.input2 = 2
+    [$pow]
+    if (std.output == 36) {[echo passed]} else {[echo failed]}
+    [echo test 2]
+    std.input = 5
+    std.input2 = 0
+    [$pow]
+    if (std.output == 1) {[echo passed]} else {[echo failed]}
+    [echo test 3]
+    std.input = 6
+    std.input2 = 3
+    [$pow]
+    if (std.output == 216) {[echo passed]} else {[echo failed]}
+    [echo test 4]
+    std.input = 0
+    std.input2 = 4
+    [$pow]
+    if (std.output == 0) {[echo passed]} else {[echo failed]}
+    [echo test 5]
+    std.input = 3
+    std.input2 = 1
+    [$pow]
+    if (std.output == 3) {[echo Passed]} else {[echo failed]}
+}
+
+sandbox test_std_sqrt
+
+map {
+    test_event: @test
+}
+
+service test {
+    [echo testing std sqrt]
+    [echo test 1]
+    std.input = 64
+    [$sqrt]
+    if (std.output == 8) {[echo passed]} else {[echo failed]}
+    [echo test 2]
+    std.input = 255
+    [$sqrt]
+    if (std.output == 15) {[echo passed]} else {[echo failed]}
+    [echo test 3]
+    std.input = 0
+    [$sqrt]
+    if (std.output == 0) {[echo passed]} else {[echo failed]}
+    [echo test 4]
+    std.input = 1
+    [$sqrt]
+    if (std.output == 1) {[echo passed]} else {[echo failed]}
+}
+
 sandbox test_std_print
 
 map {


### PR DESCRIPTION
Going into macros branch to avoid conflicts with master.

Pow gets the answer of input raised to the power of input2.

Sqrt gets the floored square root of input.

You should probably add the standard library to the wiki once 1.2 is finalized